### PR TITLE
🔖 Added sudo access for Gnome 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,6 @@
   "settings-schema": "org.gnome.shell.extensions.big-avatar",
   "version": 10,
   "shell-version": [
-    "40","41"
+    "40","41","42"
   ]
 }


### PR DESCRIPTION
Added 42 to `metadata.json` to make it available on Gnome 42. The extension works as expected without any change needed.